### PR TITLE
fix: move debug config to config.py and remove inline env access

### DIFF
--- a/app_backend/config.py
+++ b/app_backend/config.py
@@ -2,6 +2,7 @@ import os
 
 stats_db_uri = os.getenv("STATS_DB_URI", "postgres://postgres:password@127.0.0.1/postgres")
 debug_user_email = os.getenv("DEBUG_USER_EMAIL")
+debug = os.getenv("DEBUG", "").lower() in ["true", "1", "yes"]
 
 host = os.getenv("HOST", "127.0.0.1")
 port = int(os.getenv("PORT", "8000"))

--- a/app_backend/server.py
+++ b/app_backend/server.py
@@ -7,6 +7,7 @@ import fastapi
 import uvicorn
 from fastapi.middleware.cors import CORSMiddleware
 
+from app_backend import config
 from app_backend.auth import user_from_header_or_token
 from app_backend.metta_repo import MettaRepo
 from app_backend.routes import dashboard_routes, sql_routes, stats_routes, token_routes
@@ -33,8 +34,9 @@ def setup_logging():
         return
 
     # Configure root logger
+    log_level = logging.DEBUG if config.debug else logging.INFO
     logging.basicConfig(
-        level=logging.INFO,
+        level=log_level,
         format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
         handlers=[logging.StreamHandler(sys.stdout)],
     )


### PR DESCRIPTION
## Summary
- Extracted DEBUG environment variable handling to config.py
- Removed inline os.getenv() call from server.py
- Now using config module for all environment variable access

## Why
Per PR feedback, inline imports and getting env values outside of config are code smells that should be avoided.

## Testing
- Verified logging level changes based on DEBUG env var
- All existing tests pass