### PR TITLE
docs: add git operations section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,20 @@ make clean
 make test
 ```
 
+### Git Operations
+
+When running git commands that trigger pre-commit hooks (like `git commit`), you need to activate the virtual environment first:
+
+```bash
+# For git commands that run pre-commit hooks
+source .venv/bin/activate && git commit -m "your commit message"
+
+# Alternative: use the venv's git directly
+.venv/bin/git commit -m "your commit message"
+```
+
+This is necessary because pre-commit hooks (like ruff formatting) are installed in the virtual environment.
+
 ## Code Architecture
 
 ### Agent System


### PR DESCRIPTION
## Summary
Added documentation about needing to activate the virtual environment when running git commands that trigger pre-commit hooks.

## Why
Discovered that `git commit` fails with "ruff is not installed" error when the virtual environment is not activated, because pre-commit hooks are installed in the venv.

## Changes
- Added new "Git Operations" section to CLAUDE.md
- Documented two ways to run git commands with venv
- Explained why this is necessary

This will help future developers (and Claude) avoid this common pitfall.